### PR TITLE
Update icons and screenshots from the excel file

### DIFF
--- a/WebBasedData/screenshot-database-v2.json
+++ b/WebBasedData/screenshot-database-v2.json
@@ -1,8 +1,8 @@
 {
     "package_count": {
         "total": 11712,
-        "done": 5119,
-        "packages_with_icon": 5119,
+        "done": 5118,
+        "packages_with_icon": 5118,
         "packages_with_screenshot": 590,
         "total_screenshots": 1834
     },
@@ -17180,7 +17180,7 @@
             "images": []
         },
         "gradle": {
-            "icon": "https://community.chocolatey.org/content/packageimages/gradle.7.6.png",
+            "icon": "",
             "images": []
         },
         "gradle-bin": {


### PR DESCRIPTION
## Summary by Sourcery

Update the screenshot database to correct package counts and remove the icon URL for the 'gradle' package.

Bug Fixes:
- Correct the package count for 'done' and 'packages_with_icon' from 5119 to 5118.

Enhancements:
- Remove the icon URL for the 'gradle' package, leaving it empty.